### PR TITLE
Week011

### DIFF
--- a/src/DIYDoom/ViewRenderer.h
+++ b/src/DIYDoom/ViewRenderer.h
@@ -19,7 +19,7 @@ public:
     void AddWallInFOV(Seg seg, Angle V1Angle, Angle V2Angle);
     void InitFrame();
     void SetDrawColor(int R, int G, int B);
-    void DrawRect(int X, int Y, int Width, int Height);
+    void DrawRect(int X, int Y, int X2, int Y2);
     void DrawLine(int X1, int Y1, int X2, int Y2);
 
 protected:

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -59,7 +59,7 @@ public:
     void AddWallInFOV(Seg seg, Angle V1Angle, Angle V2Angle);
     void InitFrame();
     void SetDrawColor(int R, int G, int B);
-    void DrawRect(int X, int Y, int Width, int Height);
+    void DrawRect(int X, int Y, int X2, int Y2);
     void DrawLine(int X1, int Y1, int X2, int Y2);
 
 protected:


### PR DESCRIPTION
Fix for a minor inconsistency between definition and implementation 

In `ViewRenderer.h`:
```cpp
void DrawRect(int X, int Y, int Width, int Height);
```
In `ViewRenderer.cpp` the variables are defined as `X2` and `Y2`:

```cpp
void ViewRenderer::DrawRect(int X1, int Y1, int X2, int Y2)
```

This PR applies the X2/Y2 naming up to the definition (and updated the article)